### PR TITLE
Fix issue with url-generator where request-object has null nested class+properties

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,4 +3,7 @@
   <packageSources>
     <add key="NuGet.org" value="https://nuget.org/api/v2/" />
   </packageSources>
+  <disabledPackageSources>
+    <add key="nuget.org" value="true" />
+  </disabledPackageSources>
 </configuration>

--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <PatchVersion>4</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/Extensions.cs
+++ b/src/Core/Extensions.cs
@@ -92,7 +92,11 @@ namespace RimDev.Supurlative
                         || (!string.IsNullOrEmpty(property.PropertyType.Namespace)
                         && property.PropertyType.Namespace.StartsWith("System")))
                     {
-                        kvp.Add(fullPropertyName, (valueOrPropertyType != null ? valueOrPropertyType.ToString() : string.Empty));
+                        var kvpValue = (valueOrPropertyType != null && valueOrPropertyType as Type == null
+                            ? valueOrPropertyType.ToString()
+                            : null);
+
+                        kvp.Add(fullPropertyName, kvpValue);
                     }
                     else
                     {

--- a/tests/Core.Tests/UrlGeneratorTests.cs
+++ b/tests/Core.Tests/UrlGeneratorTests.cs
@@ -56,5 +56,27 @@ namespace RimDev.Supurlative.Tests
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void Make_sure_null_nested_class_property_values_do_not_show_in_url()
+        {
+            var request = new TestNestedClass { Id = 1 };
+            var result = Generator.Generate("foo.show", request);
+
+            Assert.Equal("http://localhost:8000/foo/1", result);
+        }
+
+        public class TestNestedClass
+        {
+            public int Id { get; set; }
+
+            public NestedClass Filter { get; set; }
+
+            public class NestedClass
+            {
+                public int Level { get; set; }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Previous behavior would generate url with property-type as value (i.e. int nestedProperty => http://example.com/?nestedProperty=System.Int32).
