### PR TITLE
Fix GetNames to work with HostedHttpRouteCollection

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>5</PatchVersion>
+    <PatchVersion>6</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tests/Core.Tests/Core.Tests.csproj
+++ b/tests/Core.Tests/Core.Tests.csproj
@@ -46,8 +46,13 @@
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -76,6 +81,7 @@
     <Compile Include="..\..\common\SolutionInfo.cs">
       <Link>Properties\SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="ExtensionTests.cs" />
     <Compile Include="FormattingTests.cs" />
     <Compile Include="TemplateUrlTests.cs" />
     <Compile Include="TemplateTests.cs" />

--- a/tests/Core.Tests/ExtensionTests.cs
+++ b/tests/Core.Tests/ExtensionTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Web.Http;
+using System.Web.Http.WebHost.Routing;
+using System.Web.Routing;
+using Xunit;
+
+namespace RimDev.Supurlative.Tests
+{
+    public class ExtensionTests
+    {
+        [Fact]
+        public void Can_get_names_from_a_HttpRouteCollection()
+        {
+            var routes = WebApiHelper.GetRequest().GetConfiguration().Routes;
+            var names = routes.GetNames();
+            Assert.True(names.Count > 0);
+        }
+
+        [Fact]
+        public void Can_get_names_from_a_HostedHttpRouteCollection()
+        {
+            var assembly = Assembly.Load("System.Web.Http.WebHost");
+            var type = assembly.GetType("System.Web.Http.WebHost.Routing.HostedHttpRouteCollection");
+
+            var routeCollection = new RouteCollection();
+
+            routeCollection.MapHttpRoute("one", "one");
+            routeCollection.MapHttpRoute("two", "two");
+            routeCollection.MapHttpRoute("three", "three");
+
+            var hostedRoutes = Activator.CreateInstance(type, routeCollection) as HttpRouteCollection;
+
+            var names = hostedRoutes.GetNames();
+            Assert.True(names.Count > 0);
+        }
+    }
+}

--- a/tests/Core.Tests/packages.config
+++ b/tests/Core.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net451" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
   <package id="Tavis.UriTemplates" version="0.6.3" targetFramework="net451" />
   <package id="xunit" version="2.0.0" targetFramework="net451" />


### PR DESCRIPTION
.NET is built on a house of cards.

![](http://media0.giphy.com/media/fCkd0tasUZpDi/giphy.gif)
