### PR TITLE
Fix issue where traversing an object for properties

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>6</PatchVersion>
+    <PatchVersion>7</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/Extensions.cs
+++ b/src/Core/Extensions.cs
@@ -96,9 +96,13 @@ namespace RimDev.Supurlative
 
                 if (formatterAttribute != null)
                 {
+                    var targetValue = target == null || target as Type != null
+                        ? null
+                        : property.GetValue(target, null);
+
                     formatterAttribute.Invoke(
                         fullPropertyName,
-                        property.GetValue(target, null),
+                        targetValue,
                         property.PropertyType,
                         kvp,
                         options);


### PR DESCRIPTION
Does not work for properties == Type when getting value of property based on initial object.

Related to getting value to pass to formatter.
