### PR TITLE
Add FormatterException

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>7</PatchVersion>
+    <PatchVersion>8</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -58,6 +58,7 @@
     </Compile>
     <Compile Include="BaseFormatterAttribute.cs" />
     <Compile Include="Extensions.cs" />
+    <Compile Include="FormatterException.cs" />
     <Compile Include="Generator.cs" />
     <Compile Include="LamdaFormatter.cs" />
     <Compile Include="NullableFormatter.cs" />

--- a/src/Core/Extensions.cs
+++ b/src/Core/Extensions.cs
@@ -100,12 +100,21 @@ namespace RimDev.Supurlative
                         ? null
                         : property.GetValue(target, null);
 
-                    formatterAttribute.Invoke(
-                        fullPropertyName,
-                        targetValue,
-                        property.PropertyType,
-                        kvp,
-                        options);
+                    try
+                    {
+                        formatterAttribute.Invoke(
+                            fullPropertyName,
+                            targetValue,
+                            property.PropertyType,
+                            kvp,
+                            options);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new FormatterException(
+                            string.Format("There is a problem invoking the formatter: {0}.", formatterAttribute.GetType().FullName),
+                            ex);
+                    }
                 }
                 else
                 {

--- a/src/Core/FormatterException.cs
+++ b/src/Core/FormatterException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace RimDev.Supurlative
+{
+    public class FormatterException : Exception
+    {
+        public FormatterException(
+            string message,
+            Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/tests/Core.Tests/FormattingTests.cs
+++ b/tests/Core.Tests/FormattingTests.cs
@@ -101,6 +101,27 @@ namespace RimDev.Supurlative.Tests
 
             Assert.Equal(expected, actual.Url);
         }
+
+        [Fact]
+        public void Should_throw_formatter_exception_if_formatter_throws_exception_during_generation()
+        {
+            var request = WebApiHelper.GetRequest();
+            var configuration = request.GetConfiguration();
+
+            configuration.Routes.MapHttpRoute("test", "test");
+
+            var options = SupurlativeOptions.Defaults;
+
+            options.AddFormatter<DummyFormatter>();
+
+            var generator = new Generator(request, options);
+            var exception = Assert.Throws<FormatterException>(
+                () => generator.Generate("test", new { Id = 1 }));
+
+            Assert.Equal(
+                "There is a problem invoking the formatter: RimDev.Supurlative.Tests.DummyFormatter.",
+                exception.Message);
+        }
     }
 
     public class LocationRequest
@@ -165,6 +186,19 @@ namespace RimDev.Supurlative.Tests
         public override bool IsMatch(Type currentType, SupurlativeOptions options)
         {
             return IsMatch(typeof(Dictionary<string, object>), currentType, options);
+        }
+    }
+
+    public class DummyFormatter : BaseFormatterAttribute
+    {
+        public override void Invoke(string fullPropertyName, object value, Type valueType, IDictionary<string, object> dictionary, SupurlativeOptions options)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool IsMatch(Type currentType, SupurlativeOptions options)
+        {
+            return true;
         }
     }
 }


### PR DESCRIPTION
This is intended for usage within Extensions class during traversing of object-keys.
Previous behavior would allow a formatter to throw an uncaught exception for any number of reasons (ex. value is null and not handled by formatter).
This made it difficult to debug the cause of any problem.
New behavior wraps any format-related exception as a FormatterException.
