### PR TITLE
Update Extensions behavior to allow getter-only interfaces properties to appear in template url

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>8</PatchVersion>
+    <PatchVersion>9</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Core/Extensions.cs
+++ b/src/Core/Extensions.cs
@@ -118,23 +118,30 @@ namespace RimDev.Supurlative
                 }
                 else
                 {
+                    var kvpValue = (valueOrPropertyType != null && valueOrPropertyType as Type == null
+                            ? valueOrPropertyType.ToString()
+                            : null);
+
                     if (property.PropertyType.IsPrimitive
                         || (!string.IsNullOrEmpty(property.PropertyType.Namespace)
                         && property.PropertyType.Namespace.StartsWith("System")))
                     {
-                        var kvpValue = (valueOrPropertyType != null && valueOrPropertyType as Type == null
-                            ? valueOrPropertyType.ToString()
-                            : null);
-
                         kvp.Add(fullPropertyName, kvpValue);
                     }
                     else
                     {
                         var results = TraverseForKeys(valueOrPropertyType, options, fullPropertyName);
 
-                        foreach (var result in results)
+                        if (results.Count() == 0)
                         {
-                            kvp.Add(result.Key, result.Value);
+                            kvp.Add(fullPropertyName, kvpValue);
+                        }
+                        else
+                        {
+                            foreach (var result in results)
+                            {
+                                kvp.Add(result.Key, result.Value);
+                            }
                         }
                     }
                 }

--- a/tests/Core.Tests/TemplateTests.cs
+++ b/tests/Core.Tests/TemplateTests.cs
@@ -134,6 +134,16 @@ namespace RimDev.Supurlative.Tests
             Assert.Equal(expected, actual);
         }
 
+        [Fact]
+        public void Can_handle_open_generic_interface()
+        {
+            var expected = "http://localhost:8000/foo/{id}{?test}";
+
+            var actual = Generator.Generate<WithInterface>("foo.show");
+
+            Assert.Equal(expected, actual);
+        }
+
         private class ComplexRouteParameters
         {
             public ComplexRouteParameters()
@@ -149,6 +159,17 @@ namespace RimDev.Supurlative.Tests
                 public string Abc { get; set; }
                 public string Def { get; set; }
             }
+        }
+
+        private class WithInterface
+        {
+            public int Id { get; set; }
+            public ITest<int> Test { get; set; }
+        }
+
+        public interface ITest<T>
+        {
+            T First { get; }
         }
     }
 }


### PR DESCRIPTION
Previous behavior would not add property to collection of keys since the propertie's type was an interface with getter-only properties.

See [implementation](https://github.com/ritterim/Supurlative/blob/4eb7a4733014f3e325b94d637bf2d12d6a3b80bb/src/Core/Extensions.cs#L66) for property-scan logic.
