### PR TITLE
Fix issue of singleton causing false-positives during running of full test-suite

### DIFF
--- a/src/Core/SupurlativeOptions.cs
+++ b/src/Core/SupurlativeOptions.cs
@@ -5,8 +5,13 @@ namespace RimDev.Supurlative
 {
     public class SupurlativeOptions
     {
-        public static readonly SupurlativeOptions Defaults =
-            new SupurlativeOptions();
+        public static SupurlativeOptions Defaults
+        {
+            get
+            {
+                return new SupurlativeOptions();
+            }
+        }
 
         public UriKind UriKind { get; set; }
         public string PropertyNameSeperator { get; set; }


### PR DESCRIPTION
Commit 0de2fbaf70a6617a00243c26871cda53bafb3101 introduced a `DummyFormatter` which is intended to throw an exception during invoking of the formatter.
Related tests capture this exception.

However, since most tests use the `SupurlativeOptions.Defaults` singleton, other tests adding formatters get passed to tests not expecting this formatters.
And, based on the ordering of when tests are executed (seems random between VS2013, VS2015, command-line runners), some tests get the `DummyFormatter` which causes that test to throw a false-positive.
This behavior is interesting since the previous assumption is that each test is run independently and the full-stack is tore down and rebuilt between tests.
New behavior retains static defaults property (to retain backwards compatibility), but now creates a new instance with each call.
A better approach might include just resetting formatters within the test-suite.
