### PR TITLE
Refactor PagingGeneratorTests

### DIFF
--- a/tests/Paging.Tests/Paging.Tests.csproj
+++ b/tests/Paging.Tests/Paging.Tests.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="PagingGeneratorTests.cs" />
+    <Compile Include="PagingTestHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Paging.Tests/PagingTestHelper.cs
+++ b/tests/Paging.Tests/PagingTestHelper.cs
@@ -1,0 +1,28 @@
+﻿using RimDev.Supurlative.Tests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace RimDev.Supurlative.Paging.Tests
+{
+    public static class PagingTestHelper
+    {
+        public static PagingGenerator CreateAPagingGenerator(
+            string baseUrl,
+            string routeName,
+            string routeTemplate,
+            object routeDefaults = null,
+            object routeConstraints = null,
+            SupurlativeOptions supurlativeOptions = null
+            )
+        {
+            HttpRequestMessage request;
+            request = TestHelper.CreateAHttpRequestMessage(baseUrl, routeName, routeTemplate, routeDefaults, routeConstraints);
+            return new PagingGenerator(request, supurlativeOptions);
+        }
+    }
+}


### PR DESCRIPTION
- Adds a PagingTestHelper class similar to PR #17
- Refactors PagingGenerator tests to use new helper

This reduces dependency on WebApiHelper (which is a Mystery Guest) and should make it easier to understand the paging tests.
