### PR TITLE
Refactor FormattingTests to use TestHelper

### DIFF
--- a/tests/Core.Tests/FormattingTests.cs
+++ b/tests/Core.Tests/FormattingTests.cs
@@ -8,55 +8,45 @@ namespace RimDev.Supurlative.Tests
 {
     public class FormattingTests
     {
-        public FormattingTests()
-        {
-            var request = WebApiHelper.GetRequest();
-
-            var configuration = request.GetConfiguration();
-            configuration.Routes.MapHttpRoute("dictionary", "values");
-            configuration.Routes.MapHttpRoute("location", "place");
-            configuration.Routes.MapHttpRoute("party", "party");
-            configuration.Routes.MapHttpRoute("nullable", "nullable");
-
-            var options = SupurlativeOptions.Defaults;
-            options.AddFormatter<NullableFormatter>();
-
-            Generator = new Generator(request, options);
-        }
-
-        private readonly Generator Generator;
+        const string _baseUrl = "http://localhost:8000/";
 
         [Fact]
         public void Can_generate_a_url_with_complex_object_using_formatter()
         {
+            string expectedUrl = _baseUrl + "place?location=0-0";
+            const string routeName = "location";
+            const string routeTemplate = "place";
 
-            var expected = "http://localhost:8000/place?location=0-0";
-            var actual = Generator.Generate("location", new LocationRequest
-            {
-                Location = new LocationRequest.Coordinate
+            Result actual = TestHelper.CreateAGenerator(_baseUrl, routeName, routeTemplate)
+                .Generate(routeName, new LocationRequest
                 {
-                    X = 0,
-                    Y = 0
-                }
-            });
-
-            Assert.Equal(expected, actual.Url);
+                    Location = new LocationRequest.Coordinate
+                    {
+                        X = 0,
+                        Y = 0
+                    }
+                });
+            Assert.Equal(expectedUrl, actual.Url);
         }
 
         [Fact]
         public void Can_generate_a_url_with_complex_object_using_dictionary_formatter()
         {
-            var expectedTemplate = "http://localhost:8000/values{?one,two,three}";
-            var expectedUrl = "http://localhost:8000/values?one=1&two=2&three=3";
-            var actual = Generator.Generate("dictionary", new DictionaryRequest
-            {
-                Dictionary = new Dictionary<string, string>()
+            var expectedTemplate = _baseUrl + "values{?one,two,three}";
+            var expectedUrl = _baseUrl + "values?one=1&two=2&three=3";
+            const string routeName = "dictionary";
+            const string routeTemplate = "values";
+
+            Result actual = TestHelper.CreateAGenerator(_baseUrl, routeName, routeTemplate)
+                .Generate(routeName, new DictionaryRequest
                 {
-                    { "one", "1" },
-                    { "two", "2" },
-                    { "three", "3" }
-                }
-            });
+                    Dictionary = new Dictionary<string, string>()
+                    {
+                        { "one", "1" },
+                        { "two", "2" },
+                        { "three", "3" }
+                    }
+                });
 
             Assert.Equal(expectedTemplate, actual.Template);
             Assert.Equal(expectedUrl, actual.Url);
@@ -65,56 +55,63 @@ namespace RimDev.Supurlative.Tests
         [Fact]
         public void Can_generate_a_url_with_global_formatter()
         {
-            var expected = "http://localhost:8000/party?date=07-15-2015";
+            string expectedUrl = _baseUrl + "party?date=07-15-2015";
+            const string routeName = "party";
+            const string routeTemplate = "party";
 
-            Generator
-                .Options
-                .AddFormatter<DateTime>(x => x.ToString("MM-dd-yyyy"));
+            Generator generator = TestHelper.CreateAGenerator(_baseUrl, routeName, routeTemplate);
+            generator.Options.AddFormatter<DateTime>(x => x.ToString("MM-dd-yyyy"));
+            Result actual = generator
+                .Generate(routeName, new PartyRequest
+                {
+                    Date = new System.DateTime(2015, 7, 15)
+                });
 
-            var actual = Generator.Generate("party", new PartyRequest
-            {
-                Date = new System.DateTime(2015, 7, 15)
-            });
-
-            Assert.Equal(expected, actual.Url);
+            Assert.Equal(expectedUrl, actual.Url);
         }
 
         [Fact]
         public void Can_handle_nullable_value_with_value()
         {
-            var expected = "http://localhost:8000/nullable?age=1";
+            string expectedUrl = _baseUrl + "nullable?age=1";
+            const string routeName = "nullable";
+            const string routeTemplate = "nullable";
 
-            var actual = Generator.Generate("nullable", new NullableRequest
-            {
-                Age = 1
-            });
+            Result actual = TestHelper.CreateAGenerator(_baseUrl, routeName, routeTemplate)
+                .Generate(routeName, new NullableRequest
+                {
+                    Age = 1
+                });
 
-            Assert.Equal(expected, actual.Url);
+            Assert.Equal(expectedUrl, actual.Url);
         }
 
         [Fact]
         public void Can_handle_nullable_value_with_no_value()
         {
-            var expected = "http://localhost:8000/nullable";
+            string expectedUrl = _baseUrl + "nullable";
+            const string routeName = "nullable";
+            const string routeTemplate = "nullable";
 
-            var actual = Generator.Generate("nullable", new NullableRequest());
+            Result actual = TestHelper.CreateAGenerator(_baseUrl, routeName, routeTemplate)
+                .Generate(routeName, new NullableRequest());
 
-            Assert.Equal(expected, actual.Url);
+            Assert.Equal(expectedUrl, actual.Url);
         }
 
         [Fact]
         public void Should_throw_formatter_exception_if_formatter_throws_exception_during_generation()
         {
-            var request = WebApiHelper.GetRequest();
-            var configuration = request.GetConfiguration();
-
-            configuration.Routes.MapHttpRoute("test", "test");
-
-            var options = SupurlativeOptions.Defaults;
-
+            const string routeName = "test";
+            const string routeTemplate = "test";
+            SupurlativeOptions options = SupurlativeOptions.Defaults;
             options.AddFormatter<DummyFormatter>();
 
+            HttpRequestMessage request;
+            request = TestHelper.CreateAHttpRequestMessage(_baseUrl, routeName, routeTemplate);
+
             var generator = new Generator(request, options);
+
             var exception = Assert.Throws<FormatterException>(
                 () => generator.Generate("test", new { Id = 1 }));
 


### PR DESCRIPTION
Refactor tests to eliminate dependency on the Mystery Guest WebApiHelper class.  Try to make it clearer what is being tested by defining all the constants/strings inside the test methods.
