### PR TITLE
Refactor URL Generator tests

### DIFF
--- a/src/Core/UrlGenerator.cs
+++ b/src/Core/UrlGenerator.cs
@@ -27,7 +27,7 @@ namespace RimDev.Supurlative
 
             var values = request.TraverseForKeys(options: Options);
 
-            var link = UriKind.Absolute == UriKind.Relative
+            var link = Options.UriKind == UriKind.Relative
                 ? urlHelper.Route(routeName, values)
                 : urlHelper.Link(routeName, values);
 


### PR DESCRIPTION
- Fixes a bug in URL Genenerator (would never return relative URIs)
- Remove dependency on mystery guest WebApiHelper
- Add Can_generate_a_relative_path
- Add Can_generate_two_optional_path_items_template_two
- Add Make_sure_nested_class_property_values_do_show_in_url
- Add Make_sure_generic_nested_class_property_values_do_show_in_url
