### PR TITLE
Remove dependency on PagedList Project

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="NuGet.org" value="https://nuget.org/api/v2/" />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To get started using **SupUrlative**, first install the library from Nuget using
 PM> Install-Package RimDev.Supurlative
 ```
 
-You may optionally add the **Paging** extension if you are going to use the PagedList Nuget package.
+You may optionally add the **Paging** extension if you are going to use **any** PagedList Nuget package.
 
 ```
 PM> Install-Package RimDev.Supurlative.Paging
@@ -151,6 +151,35 @@ var result = Generator.Generate("page.query",
 // http://localhost:8000/paging?page=2
 result.NextUrl;
 ```
+
+The `PagedList` property can have one of two contracts:
+
+The first is the common PagedList interface found in many common PagedList
+implementations.
+
+```csharp
+public interface IPagedList
+{
+    int PageNumber { get; }
+    int PageSize { get; }
+    int TotalItemCount { get; }
+}
+```
+
+The second interface is something proprietary to the Supurlative package.
+
+```csharp
+public interface IPaged
+{
+    int? Page { get; }
+    int? PageSize { get; }
+    int? TotalItemCount { get; }
+}
+```
+
+Note: You **do not** have to explicitly implement these interfaces on your types, you
+just have to have these properties on the parameter object you are passing
+to the `Generate` method.
 
 When generating paging urls, you will get a `PagingResult` from the generator. The following are the properties you will have access from the result.
 

--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>1</MinorVersion>
+    <MinorVersion>2</MinorVersion>
     <PatchVersion>0</PatchVersion>
   </PropertyGroup>
 

--- a/src/Paging/DynamicBinderExtensions.cs
+++ b/src/Paging/DynamicBinderExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace RimDev.Supurlative.Paging
+{
+    internal static class DynamicBinderExtensions
+    {
+        internal static bool Has<TType, TReturn>(this TType target, Func<TType, TReturn> test)
+        {
+            try
+            {
+                var value = test(target);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Paging/IPaged.cs
+++ b/src/Paging/IPaged.cs
@@ -1,0 +1,9 @@
+﻿namespace RimDev.Supurlative.Paging
+{
+    public interface IPaged
+    {
+        int? Page { get; }
+        int? PageSize { get; }
+        int? TotalItemCount { get; }
+    }
+}

--- a/src/Paging/IPagedList.cs
+++ b/src/Paging/IPagedList.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace RimDev.Supurlative.Paging
+﻿namespace RimDev.Supurlative.Paging
 {
     /// <summary>
     /// Not necessary to implement,
@@ -13,21 +11,5 @@ namespace RimDev.Supurlative.Paging
         int PageNumber { get; }
         int PageSize { get; }
         int TotalItemCount { get; }
-    }
-
-    internal static class DynamicBinderExtensions
-    {
-        internal static bool Has<TType, TReturn>(this TType target, Func<TType, TReturn> test)
-        {
-            try
-            {
-                var value = test(target);
-                return true;
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-        }
     }
 }

--- a/src/Paging/IPagedList.cs
+++ b/src/Paging/IPagedList.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace RimDev.Supurlative.Paging
+{
+    /// <summary>
+    /// Not necessary to implement,
+    /// here to define the interface of
+    /// PagedList
+    /// https://www.nuget.org/packages/PagedList/
+    /// </summary>
+    public interface IPagedList
+    {
+        int PageNumber { get; }
+        int PageSize { get; }
+        int TotalItemCount { get; }
+    }
+
+    internal static class DynamicBinderExtensions
+    {
+        internal static bool Has<TType, TReturn>(this TType target, Func<TType, TReturn> test)
+        {
+            try
+            {
+                var value = test(target);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Paging/PagedListShim.cs
+++ b/src/Paging/PagedListShim.cs
@@ -1,0 +1,21 @@
+﻿namespace RimDev.Supurlative.Paging
+{
+    /// <summary>
+    /// Used to Shim PagedList into 
+    /// the IPaged, which is what
+    /// we want now
+    /// </summary>
+    internal class PagedListShim : IPaged
+    {
+        private readonly IPagedList shim;
+
+        public PagedListShim(IPagedList shim)
+        {
+            this.shim = shim;
+        }
+
+        public int? Page => shim.PageNumber;
+        public int? PageSize => shim.PageSize;
+        public int? TotalItemCount => shim.TotalItemCount;
+    }
+}

--- a/src/Paging/Paging.csproj
+++ b/src/Paging/Paging.csproj
@@ -30,12 +30,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="ImpromptuInterface, Version=6.2.2.0, Culture=neutral, PublicKeyToken=0b1781c923b2975b, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\ImpromptuInterface.6.2.2\lib\net40\ImpromptuInterface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="PagedList, Version=1.17.0.0, Culture=neutral, PublicKeyToken=abbb863e9397c5e1, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\PagedList.1.17.0.0\lib\net40\PagedList.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -48,6 +48,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IPagedList.cs" />
+    <Compile Include="IPaged.cs" />
+    <Compile Include="PagedListShim.cs" />
     <Compile Include="PagingGenerator.cs" />
     <Compile Include="PagingResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Paging/Paging.csproj
+++ b/src/Paging/Paging.csproj
@@ -48,6 +48,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DynamicBinderExtensions.cs" />
     <Compile Include="IPagedList.cs" />
     <Compile Include="IPaged.cs" />
     <Compile Include="PagedListShim.cs" />

--- a/src/Paging/packages.config
+++ b/src/Paging/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ImpromptuInterface" version="6.2.2" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net451" />
-  <package id="PagedList" version="1.17.0.0" targetFramework="net451" />
 </packages>

--- a/tests/Paging.Tests/PagingGeneratorTests.cs
+++ b/tests/Paging.Tests/PagingGeneratorTests.cs
@@ -3,7 +3,6 @@ using RimDev.Supurlative.Tests;
 using System;
 using System.Linq;
 using System.Net.Http;
-using System.Web.Http;
 using Xunit;
 
 namespace RimDev.Supurlative.Paging.Tests
@@ -17,7 +16,13 @@ namespace RimDev.Supurlative.Paging.Tests
             PagedList = Enumerable
                 .Range(1, 100)
                 .ToPagedList(1, 10);
+        }
 
+        public class OurPagedList
+        {
+            public int? Page { get; } = 1;
+            public int? PageSize { get; } = 10;
+            public int? TotalItemCount { get; } = 100;
         }
 
         private readonly IPagedList<int> PagedList;
@@ -30,6 +35,21 @@ namespace RimDev.Supurlative.Paging.Tests
 
             PagingResult result = PagingTestHelper.CreateAPagingGenerator(_baseUrl, routeName, routeTemplate)
                 .Generate(routeName, new Request { page = 1 }, PagedList);
+
+            Assert.True(result.HasNext);
+            Assert.False(result.HasPrevious);
+            Assert.Equal(expectedUrl, result.NextUrl);
+        }
+
+        [Fact]
+        public void Can_generate_paged_result_with_query_string_using_object_like_IPagedTarget()
+        {
+            string expectedUrl = _baseUrl + "paging?page=2&currentpagenumber=0";
+            const string routeName = "page.query";
+            const string routeTemplate = "paging";
+
+            PagingResult result = PagingTestHelper.CreateAPagingGenerator(_baseUrl, routeName, routeTemplate)
+                .Generate(routeName, new Request { page = 1 }, new OurPagedList());
 
             Assert.True(result.HasNext);
             Assert.False(result.HasPrevious);


### PR DESCRIPTION
We still support `PagedList` implementations and this change is
backwards compatible. It just now supports two acceptable interfaces
of `IPagedList` and `IPaged` to generate urls. This supports the
community while also supporting our internal implementations at
RIMdev.

All done via Black Voodoo magic.

![](https://media3.giphy.com/media/qJAldj3OK3BQc/giphy.gif)