### PR TITLE
Fix expression resolver during paging generator

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>1</PatchVersion>
+    <PatchVersion>2</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Paging/PagingGenerator.cs
+++ b/src/Paging/PagingGenerator.cs
@@ -114,15 +114,23 @@ namespace RimDev.Supurlative.Paging
 
             if (expression != null)
             {
-                var unaryExpression = expression.Body as UnaryExpression;
+                // When the actual expression property is `int?`.
+                var memberExpression = expression.Body as MemberExpression;
 
-                if (unaryExpression != null)
+                // An additional try if expression property is `int`.
+                if (memberExpression == null)
                 {
-                    var memberExpression = unaryExpression.Operand as MemberExpression;
-                    if (memberExpression != null)
+                    var unaryExpression = expression.Body as UnaryExpression;
+
+                    if (unaryExpression != null)
                     {
-                        propertyName = memberExpression.Member.Name;
+                        memberExpression = unaryExpression.Operand as MemberExpression;
                     }
+                }
+
+                if (memberExpression != null)
+                {
+                    propertyName = memberExpression.Member.Name;
                 }
             }
 

--- a/tests/Paging.Tests/PagingGeneratorTests.cs
+++ b/tests/Paging.Tests/PagingGeneratorTests.cs
@@ -100,6 +100,20 @@ namespace RimDev.Supurlative.Paging.Tests
         }
 
         [Fact]
+        public void Can_generate_paged_result_with_path_and_nullable_page_expression()
+        {
+            string expectedUrl = _baseUrl + "paging/2?page=1";
+            const string routeName = "newPage.path";
+            const string routeTemplate = "paging/{currentPageNumber}";
+
+            PagingResult result = PagingTestHelper.CreateAPagingGenerator(_baseUrl, routeName, routeTemplate)
+                .Generate(routeName, new RequestNullable { page = 1 }, PagedList, x => x.currentPageNumber);
+
+            Assert.True(result.HasNext);
+            Assert.Equal(expectedUrl, result.NextUrl);
+        }
+
+        [Fact]
         public void Can_generate_paged_result_with_previous_url()
         {
             string expectedUrl = _baseUrl + "paging/0?page=1";
@@ -132,6 +146,12 @@ namespace RimDev.Supurlative.Paging.Tests
         {
             public int page { get; set; }
             public int currentPageNumber { get; set; }
+        }
+
+        public class RequestNullable
+        {
+            public int? page { get; set; }
+            public int? currentPageNumber { get; set; }
         }
     }
 }


### PR DESCRIPTION
New behavior works for expressions where the underlying type is both `int` and `int?`.